### PR TITLE
Respect script name

### DIFF
--- a/hmac_authentication/hmacauth.py
+++ b/hmac_authentication/hmacauth.py
@@ -74,11 +74,10 @@ class HmacAuth(object):
         '''
         components = [environ['REQUEST_METHOD']]
         components.extend(self._signed_headers(environ))
-        components.append(
-            environ.get('SCRIPT_NAME', '') +
-            environ.get('PATH_INFO', '/') +
-            environ.get('QUERY_STRING', '')
-        )
+        uri = environ.get('SCRIPT_NAME', '') + environ.get('PATH_INFO', '/')
+        if environ.get('QUERY_STRING'):
+            uri = '{}?{}'.format(uri, environ['QUERY_STRING'])
+        components.append(uri)
         return '\n'.join(components) + '\n'
 
     # NOTE(mbland): I'm not sure the outbound WSGI HTTP request interface is

--- a/hmac_authentication/hmacauth.py
+++ b/hmac_authentication/hmacauth.py
@@ -50,6 +50,13 @@ def _compare_signatures(header, computed):
     return AuthenticationResultCodes.MISMATCH
 
 
+def get_uri(environ):
+    uri = environ.get('SCRIPT_NAME', '') + environ.get('PATH_INFO', '/')
+    if environ.get('QUERY_STRING'):
+        uri = '{}?{}'.format(uri, environ['QUERY_STRING'])
+    return uri
+
+
 class HmacAuth(object):
     '''HmacAuth signs outbound requests and authenticates inbound requests.
 
@@ -76,10 +83,7 @@ class HmacAuth(object):
         '''
         components = [environ['REQUEST_METHOD']]
         components.extend(self._signed_headers(environ))
-        uri = environ.get('SCRIPT_NAME', '') + environ.get('PATH_INFO', '/')
-        if environ.get('QUERY_STRING'):
-            uri = '{}?{}'.format(uri, environ['QUERY_STRING'])
-        components.append(uri)
+        components.append(get_uri(environ))
         return '\n'.join(components) + '\n'
 
     # NOTE(mbland): I'm not sure the outbound WSGI HTTP request interface is

--- a/hmac_authentication/hmacauth.py
+++ b/hmac_authentication/hmacauth.py
@@ -75,7 +75,10 @@ class HmacAuth(object):
         components = [environ['REQUEST_METHOD']]
         components.extend(self._signed_headers(environ))
         components.append(
-            environ.get('PATH_INFO', '/') + environ.get('QUERY_STRING', ''))
+            environ.get('SCRIPT_NAME', '') +
+            environ.get('PATH_INFO', '/') +
+            environ.get('QUERY_STRING', '')
+        )
         return '\n'.join(components) + '\n'
 
     # NOTE(mbland): I'm not sure the outbound WSGI HTTP request interface is

--- a/hmac_authentication/hmacauth.py
+++ b/hmac_authentication/hmacauth.py
@@ -10,8 +10,10 @@ from werkzeug.wrappers import Request
 from werkzeug.exceptions import abort, HTTPException
 
 
-AuthenticationResult = collections.namedtuple('AuthenticationResult',
-    ['result_code', 'header_signature', 'computed_signature'])
+AuthenticationResult = collections.namedtuple(
+    'AuthenticationResult',
+    ['result_code', 'header_signature', 'computed_signature'],
+)
 
 
 class AuthenticationResultCodes(enum.Enum):
@@ -91,9 +93,11 @@ class HmacAuth(object):
         return self._request_signature(environ, self._digest)
 
     def _request_signature(self, environ, digest):
-        h = hmac.new(self._secret_key.encode('utf8'),
+        h = hmac.new(
+            self._secret_key.encode('utf8'),
             self.string_to_sign(environ).encode('utf8'),
-            digest)
+            digest,
+        )
         request = Request(environ)
         if 'wsgi.input' in environ:
             h.update(request.get_data())
@@ -132,7 +136,9 @@ class HmacAuth(object):
 
 
 class HmacMiddleware(object):
-    '''WSGI middleware for authenticating incoming HTTP requests via HmacAuth'''
+    '''WSGI middleware for authenticating incoming HTTP requests via HmacAuth.
+    Borrowed from http://stackoverflow.com/a/29265847/1222326.
+    '''
 
     def __init__(self, app, hmac_auth):
         self.app = app

--- a/hmac_authentication/tests/test_hmac_authentication.py
+++ b/hmac_authentication/tests/test_hmac_authentication.py
@@ -5,7 +5,9 @@ import hashlib
 import six
 import pytest
 
-from hmac_authentication.hmacauth import HmacAuth, AuthenticationResultCodes
+from hmac_authentication.hmacauth import (
+    get_uri, HmacAuth, AuthenticationResultCodes
+)
 
 
 # These correspond to the headers used in bitly/oauth2_proxy#147.
@@ -26,6 +28,27 @@ HEADERS = [
 @pytest.fixture
 def auth():
     return HmacAuth(hashlib.sha1, 'foobar', 'Gap-Signature', HEADERS)
+
+
+class TestHelpers:
+
+    def test_get_uri(self):
+        environ = {'PATH_INFO': '/data'}
+        assert get_uri(environ) == '/data'
+
+    def test_get_uri_query_string(self):
+        environ = {
+            'PATH_INFO': '/data',
+            'QUERY_STRING': 'foo=bar'
+        }
+        assert get_uri(environ) == '/data?foo=bar'
+
+    def test_get_uri_script_name(self):
+        environ = {
+            'PATH_INFO': '/data',
+            'SCRIPT_NAME': '/proxy'
+        }
+        assert get_uri(environ) == '/proxy/data'
 
 
 class TestRequestSignature(object):


### PR DESCRIPTION
A few subtle but important changes to the `cleanup` branch that I didn't want to push directly:
- Include `SCRIPT_NAME` field in URL. Useful when apps are mounted on a sub-URL, like fec-proxy.
- If `QUERY_STRING` is truthy, prepend with "?" to get a realistic URL.

cc @mbland 
